### PR TITLE
remove bundle install in circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,7 @@ machine:
    - sudo chmod +x /usr/local/bin/docker
 
 dependencies:
-  override:
-    - bundle install
+  post:
     - rake build
 
 test:


### PR DESCRIPTION
We don't need to override commands in dependencies.
Circle CI already run bundle install as default.
However we need to launch the images build after
dependencies installation.